### PR TITLE
Adding build based on nix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -71,10 +71,9 @@ elif os.name == "nt" and methods.get_cmdline_bool("use_mingw", False):
 # want to have to pull in manually.
 # Then we prepend PATH to make it take precedence, while preserving SCons' own entries.
 env_base = Environment(tools=custom_tools)
-env_base.PrependENVPath("PATH", os.getenv("PATH"))
-env_base.PrependENVPath("PKG_CONFIG_PATH", os.getenv("PKG_CONFIG_PATH"))
-if "TERM" in os.environ:  # Used for colored output.
-    env_base["ENV"]["TERM"] = os.environ["TERM"]
+for k in ("TERM", "PATH", "PKG_CONFIG_PATH"):
+    if (k in os.environ):
+        env_base["ENV"][k] = os.environ[k]
 
 env_base.disabled_modules = []
 env_base.use_ptrcall = False

--- a/build.nix
+++ b/build.nix
@@ -1,0 +1,114 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, scons
+, pkg-config
+, udev
+, libX11
+, libXcursor
+, libXinerama
+, libXrandr
+, libXrender
+, libpulseaudio
+, libXi
+, libXext
+, libXfixes
+, freetype
+, openssl
+, alsa-lib
+, libGLU
+, zlib
+, yasm
+, withUdev ? true
+, extraModules ? []
+, python3
+}:
+
+let
+  options = {
+    touch = libXi != null;
+    pulseaudio = false;
+    udev = withUdev;
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "godot";
+  version = "3.5.1";
+
+  src = ./.;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    scons
+    udev
+    libX11
+    libXcursor
+    libXinerama
+    libXrandr
+    libXrender
+    libXi
+    libXext
+    libXfixes
+    freetype
+    openssl
+    alsa-lib
+    libpulseaudio
+    libGLU
+    zlib
+    yasm
+  ];
+
+  enableParallelBuilding = true;
+
+  sconsFlags = "target=release_debug platform=x11 tools=yes";
+
+  inherit extraModules;
+
+  prePatch = ''
+    declare -a patches=()
+    for mod in $extraModules
+    do
+      patches+=($mod/patches/*)
+      [[ -e $mod/modules ]] && cp -r $mod/modules .
+      [[ -e $mod/thirdparty ]] && cp -r $mod/thirdparty .
+      [[ -e $mod/helper_script.py ]] && ${python3}/bin/python3 $mod/helper_script.py
+    done
+    chmod -R u+rw .
+    echo $patches # ok why this make the build progress?????????
+  '';
+
+  preConfigure = ''
+    sconsFlags+=" ${
+      lib.concatStringsSep " "
+      (lib.mapAttrsToList (k: v: "${k}=${builtins.toJSON v}") options)
+    }"
+  '';
+
+  outputs = [ "out" "dev" "man" ];
+
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp bin/godot.* $out/bin/godot
+
+    mkdir "$dev"
+    cp -r modules/gdnative/include $dev
+
+    mkdir -p "$man/share/man/man6"
+    cp misc/dist/linux/godot.6 "$man/share/man/man6/"
+
+    mkdir -p "$out"/share/{applications,icons/hicolor/scalable/apps}
+    cp misc/dist/linux/org.godotengine.Godot.desktop "$out/share/applications/"
+    cp icon.svg "$out/share/icons/hicolor/scalable/apps/godot.svg"
+    cp icon.png "$out/share/icons/godot.png"
+    substituteInPlace "$out/share/applications/org.godotengine.Godot.desktop" \
+      --replace "Exec=godot" "Exec=$out/bin/godot"
+  '';
+
+  meta = with lib; {
+    homepage = "https://godotengine.org";
+    description = "Free and Open Source 2D and 3D game engine";
+    license = licenses.mit;
+    platforms = [ "i686-linux" "x86_64-linux" ];
+    maintainers = with maintainers; [ twey ];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,106 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "godot-patches": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1659846534,
+        "narHash": "sha256-Q1Bo/sOfRTcxKRDcYwo+NWIE3zMIX3AbCVy3HCKE+3A=",
+        "owner": "virtual-puppet-project",
+        "repo": "godot-patches",
+        "rev": "c13b8422cd54510875d7964da49cb00cb6894b6d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "virtual-puppet-project",
+        "repo": "godot-patches",
+        "type": "github"
+      }
+    },
+    "godot-stdout-stderr-intercept": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1659843791,
+        "narHash": "sha256-l5IXxsiWc82LW4d7/8fj4xwiqe4UvqG3vzeOBpJFwJw=",
+        "owner": "you-win",
+        "repo": "godot-stdout-stderr-intercept",
+        "rev": "65bb05f99f55a7480a585904e3b5968bc8ef7375",
+        "type": "github"
+      },
+      "original": {
+        "owner": "you-win",
+        "repo": "godot-stdout-stderr-intercept",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-pZukMP4zCA1FaBg0xHxf7KdE/Nv/C5YbDID7h2L8O7A=",
+        "path": "/nix/store/lh2p0yaqdwib1wyn0kbgwncy3iwgzvc9-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "godot-patches": "godot-patches",
+        "godot-stdout-stderr-intercept": "godot-stdout-stderr-intercept",
+        "nixpkgs": "nixpkgs",
+        "vpuppr-godot-modules": "vpuppr-godot-modules",
+        "youwin-godot-module": "youwin-godot-module"
+      }
+    },
+    "vpuppr-godot-modules": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661897164,
+        "narHash": "sha256-LSeycDqyaBgRpnzM1tgGbYSKBnVW2cz5+7tHnUjhHb0=",
+        "owner": "virtual-puppet-project",
+        "repo": "vpuppr-godot-modules",
+        "rev": "8c8aff0b8d79e33168ecc45b765381c4183781db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "virtual-puppet-project",
+        "repo": "vpuppr-godot-modules",
+        "type": "github"
+      }
+    },
+    "youwin-godot-module": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1658256872,
+        "narHash": "sha256-M8CQW7pbXoUjs96JteWFxB8PRiAX7oE5Xp1eTFVDPJY=",
+        "owner": "you-win",
+        "repo": "youwin-godot-module",
+        "rev": "0c6112407c7ca6cfb6932e70408052fb9bfd78fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "you-win",
+        "repo": "youwin-godot-module",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  description = "A very basic flake";
+  inputs = {
+    godot-patches = {
+      url = "github:virtual-puppet-project/godot-patches";
+      flake = false;
+    };
+    godot-stdout-stderr-intercept = {
+      url = "github:you-win/godot-stdout-stderr-intercept";
+      flake = false;
+    };
+    youwin-godot-module = {
+      url = "github:you-win/youwin-godot-module";
+      flake = false;
+    };
+    vpuppr-godot-modules = {
+      url = "github:virtual-puppet-project/vpuppr-godot-modules";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
+    {
+      overlays.default = final: prev: {
+        godot = final.callPackage ./build.nix {
+          extraModules = with inputs; [
+            godot-patches
+            godot-stdout-stderr-intercept
+            (final.fetchgit {
+              # TODO: fix this after nix flakes gain support for git submodules
+              url = "https://github.com/you-win/godot-toml";
+              rev = "7e79ba0ab7ce4f2982f1956f5a4db4f56097ce69";
+              fetchSubmodules = true;
+              hash = "sha256-/JJA3eTwpWgyVMjsTMTiTCYO/xGXuCeU61dALyC8aB0=";
+            })
+            youwin-godot-module
+            vpuppr-godot-modules
+          ];
+        };
+      };
+    } // flake-utils.lib.eachDefaultSystem (system: rec{
+      legacyPackages = import nixpkgs {
+        inherit system;
+        overlays = [ self.overlays.default ];
+      };
+      packages.default = legacyPackages.godot;
+    });
+}

--- a/platform/x11/detect.py
+++ b/platform/x11/detect.py
@@ -255,6 +255,12 @@ def configure(env):
     env.ParseConfig("pkg-config xrender --cflags --libs")
     env.ParseConfig("pkg-config xi --cflags --libs")
 
+
+    env.ParseConfig("pkg-config xext --cflags --libs")
+    env.ParseConfig("pkg-config xfixes --cflags --libs")
+    env.ParseConfig("pkg-config glu --cflags --libs")
+    env.ParseConfig("pkg-config zlib --cflags --libs")
+
     if env["touch"]:
         env.Append(CPPDEFINES=["TOUCH_ENABLED"])
 


### PR DESCRIPTION
This allows this specific godot to be installed via the command `nix profile install .`, after [installing nix](https://nixos.org/download.html#nix-install-linux) and adding 
```
experimental-features = nix-command flakes
```
to `~/.config/nix/nix.conf`